### PR TITLE
FindBy: disable message that recomends to use find_by instead.

### DIFF
--- a/vhl-rubocop.yml
+++ b/vhl-rubocop.yml
@@ -17,3 +17,6 @@ Metrics/LineLength:
 
 ActionFilter:
   Enabled: false
+
+FindBy:
+  Enabled: false


### PR DESCRIPTION
Rubocop shows a `C: Use find_by instead of where.first.` message, but this method belongs to rails >= 4.0.2.
