### PR TITLE
Fix ruby version to make never ruby syntax pass rubocop checks.

### DIFF
--- a/vhl-rubocop.yml
+++ b/vhl-rubocop.yml
@@ -1,6 +1,7 @@
 require: rubocop-rspec
 
 AllCops:
+  TargetRubyVersion: 2.1
   Include:
     - '**/Rakefile'
     - '**/config.ru'


### PR DESCRIPTION
Proposed to fix Ruby Version to 2.1 (or higher) to make Rubocop not to complaining about new Ruby syntax.

In particular this https://github.com/bbatsov/rubocop/issues/724
