### PR TITLE
rubocop: Fix rubocop-rspec requirement in configuration.

### DIFF
--- a/vhl-rubocop.yml
+++ b/vhl-rubocop.yml
@@ -1,7 +1,7 @@
-require: rubocop-rspec
 
 AllCops:
   Include:
+    - rubocop-rspec
     - '**/Rakefile'
     - '**/config.ru'
   Exclude:


### PR DESCRIPTION
"require: rubocop-rspec" on the yaml file was generating this error
"LoadError: cannot load such file -- the-project-path/rubocop-rspec" in
latest rubocop versions. More talk about it here:
https://github.com/bbatsov/rubocop/issues/2937.
